### PR TITLE
RANCHER-2321: Align pom.xml with template pattern

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,15 +3,17 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <name>app-rtac</name>
+  <name>${project.name}</name>
   <artifactId>app-rtac</artifactId>
   <groupId>org.folio</groupId>
   <description>Application Descriptor Repository for the FOLIO RTAC application</description>
   <version>1.0.0-SNAPSHOT</version>
 
   <properties>
+    <project.name>app-rtac</project.name>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven-release-plugin.version>3.1.1</maven-release-plugin.version>
+    <templatePath>${basedir}/${project.name}.template.json</templatePath>
   </properties>
 
   <build>
@@ -28,7 +30,7 @@
           </execution>
         </executions>
         <configuration>
-          <templatePath>${basedir}/app-rtac.template.json</templatePath>
+          <templatePath>${templatePath}</templatePath>
           <moduleRegistries>
             <registry>
               <type>okapi</type>
@@ -91,9 +93,9 @@
   </pluginRepositories>
 
   <scm>
-    <url>https://github.com/folio-org/app-rtac</url>
-    <connection>scm:git:git://github.com:folio-org/app-rtac.git</connection>
-    <developerConnection>scm:git:git@github.com:folio-org/app-rtac.git</developerConnection>
+    <url>https://github.com/folio-org/${project.name}</url>
+    <connection>scm:git:git://github.com:folio-org/${project.name}.git</connection>
+    <developerConnection>scm:git:git@github.com:folio-org/${project.name}.git</developerConnection>
     <tag>HEAD</tag>
   </scm>
 </project>


### PR DESCRIPTION
Aligns app-rtac pom.xml with template pattern for Maven parameter passing.

**Changes:**
- Add project.name and templatePath properties  
- Update configuration to use ${templatePath} and ${project.name}
- Fix SCM URLs and double https:// protocol

**Benefits:**
- Enables Maven parameter overriding
- Standardizes naming across repositories
- Supports automated workflows

**Related:** RANCHER-2321